### PR TITLE
Fix: Add 'test' to MemoryVectorMetadata type

### DIFF
--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -71,7 +71,7 @@ export interface HumanFeedback {
 
 // Extend MemoryVector metadata
 export interface MemoryVectorMetadata {
-  type: 'task' | 'conversation' | 'document' | 'code' | 'performance' | 'postmortem' | 'feedback' | 'log';
+  type: 'task' | 'conversation' | 'document' | 'code' | 'performance' | 'postmortem' | 'feedback' | 'log' | 'test';
   content: string;
   timestamp: number;
   agentId?: string;


### PR DESCRIPTION
This commit adds the 'test' type to the `MemoryVectorMetadata` interface. This was causing a type error in `dockerTestService.ts` when calling `storeMemory` with the type 'test'.