### PR TITLE
Fix: Add missing properties to AgentPerformanceMetrics

### DIFF
--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -48,6 +48,9 @@ export interface AgentPerformanceMetrics {
   taskFailureCount: number;
   feedbackScore: number;
   lastUpdated: number;
+  buildTime?: number;
+  testsPassed?: number;
+  testsFailed?: number;
 }
 
 export interface PostmortemAnalysis {


### PR DESCRIPTION
This commit adds `buildTime`, `testsPassed`, and `testsFailed` as optional properties to the `AgentPerformanceMetrics` interface. This was causing a type error in `dockerTestService.ts` when creating a metrics object.