### PR TITLE
Fix: Add string index signature to MemoryVectorMetadata

### DIFF
--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -74,6 +74,7 @@ export interface HumanFeedback {
 
 // Extend MemoryVector metadata
 export interface MemoryVectorMetadata {
+  [key: string]: any;
   type: 'task' | 'conversation' | 'document' | 'code' | 'performance' | 'postmortem' | 'feedback' | 'log' | 'test';
   content: string;
   timestamp: number;


### PR DESCRIPTION
This commit adds a string index signature to the `MemoryVectorMetadata` interface. This was causing a type error in `memoryService.ts` when creating a payload for the qdrant client.