### PR TITLE
Fix: Add generic broadcast method to WebSocketService

### DIFF
--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -94,4 +94,10 @@ export class WebSocketService {
       }));
     }
   }
+
+  broadcast(message: any) {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(message));
+    }
+  }
 }


### PR DESCRIPTION
This commit adds a generic `broadcast` method to the `WebSocketService` and updates the call in `notificationService.ts` to use it. This was causing a type error because the `broadcast` method did not exist.