### PR TITLE
Fix: Import TaskInfo in memory.ts

### DIFF
--- a/src/types/memory.ts
+++ b/src/types/memory.ts
@@ -1,3 +1,5 @@
+import { TaskInfo } from './agents';
+
 export interface MemoryVector {
   id: string;
   vector: number[];


### PR DESCRIPTION
This commit imports the `TaskInfo` type in `src/types/memory.ts`. This was causing a type error because it was used without being imported.