### PR TITLE
fix: Correct API route for fetching agents

### DIFF
--- a/src/pages/api/agents.ts
+++ b/src/pages/api/agents.ts
@@ -7,22 +7,10 @@ export default async function handler(
 ) {
   const { method, query } = req;
   const agentService = AgentService.getInstance();
-  const agentParams = query.agent as string[];
-
   switch (method) {
     case 'GET':
-      if (agentParams && agentParams.length > 0) {
-        const agentId = agentParams[0];
-        const agent = agentService.getAgent(agentId);
-        if (agent) {
-          return res.status(200).json(agent);
-        } else {
-          return res.status(404).json({ error: 'Agent not found' });
-        }
-      } else {
-        const agents = agentService.getAllAgents();
-        return res.status(200).json(agents);
-      }
+      const agents = agentService.getAllAgents();
+      return res.status(200).json(agents);
     case 'POST':
       try {
         const { role } = req.body;


### PR DESCRIPTION
The frontend was making a request to `/api/agents`, but the backend route was defined as a catch-all route `[...agent].ts`, which does not handle requests to the root of the path.

This change renames the file to `agents.ts` and simplifies the code to correctly handle requests to `/api/agents`.