### PR TITLE
fix: Correct import path in agents API route

### DIFF
--- a/src/pages/api/agents.ts
+++ b/src/pages/api/agents.ts
@@ -1,5 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next';
-import { AgentService } from '../../../services/agentService';
+import { AgentService } from '../../services/agentService';
 
 export default async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
After renaming the agents API route file, the relative import path to the AgentService was incorrect, causing the build to fail.

This change corrects the import path.