### PR TITLE
fix: Prevent WebSocket instantiation on server

### DIFF
--- a/src/utils/websocket.ts
+++ b/src/utils/websocket.ts
@@ -51,7 +51,9 @@ export class WebSocketService {
   private subscribers: Set<(data: any) => void> = new Set();
 
   constructor() {
-    this.initializeWebSocket();
+    if (typeof window !== 'undefined') {
+      this.initializeWebSocket();
+    }
   }
 
   private initializeWebSocket() {


### PR DESCRIPTION
The application was crashing on the server because the `WebSocketService` was attempting to instantiate a browser-only `WebSocket` object in the Node.js environment. This was causing the API routes to fail and return an HTML error page, which in turn caused a `TypeError` on the frontend.

This change wraps the WebSocket initialization logic in a check for the browser environment (`typeof window !== 'undefined'`), preventing the server-side crash.