### PR TITLE
feat(frontend): Add error handling to Dashboard fetches

### DIFF
--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { toast } from 'react-hot-toast';
 import AgentCard from './AgentCard';
 import WorkflowProgress from './WorkflowProgress';
 import TaskManagement from './TaskManagement';
@@ -33,15 +34,31 @@ const Dashboard = () => {
   }, []);
 
   const fetchAgents = async () => {
-    const response = await fetch('/api/agents');
-    const data = await response.json();
-    setAgents(data);
+    try {
+      const response = await fetch('/api/agents');
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data = await response.json();
+      setAgents(data);
+    } catch (error) {
+      console.error("Failed to fetch agents:", error);
+      toast.error('Failed to fetch agents');
+    }
   };
 
   const fetchWorkflows = async () => {
-    const response = await fetch('/api/workflows');
-    const data = await response.json();
-    setWorkflows(data);
+    try {
+      const response = await fetch('/api/workflows');
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+      const data = await response.json();
+      setWorkflows(data);
+    } catch (error) {
+      console.error("Failed to fetch workflows:", error);
+      toast.error('Failed to fetch workflows');
+    }
   };
 
   const renderContent = () => {


### PR DESCRIPTION
The application was crashing with a `TypeError: e.map is not a function` due to unhandled errors in the fetch calls in the `Dashboard` component. If an API call failed and returned a non-JSON response (like an HTML error page), the `response.json()` call would throw an unhandled exception.

This change adds `try...catch` blocks to the `fetchAgents` and `fetchWorkflows` functions. It also adds checks for non-ok HTTP responses. This makes the frontend more resilient to API failures, preventing the client-side crash and providing helpful error notifications to the user.