### PR TITLE
fix(frontend): Add defensive array check in Dashboard

### DIFF
--- a/frontend/src/components/Dashboard.jsx
+++ b/frontend/src/components/Dashboard.jsx
@@ -40,7 +40,13 @@ const Dashboard = () => {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const data = await response.json();
-      setAgents(data);
+      if (Array.isArray(data)) {
+        setAgents(data);
+      } else {
+        console.error("Received non-array data for agents:", data);
+        toast.error('Received invalid data for agents');
+        setAgents([]); // Set to empty array to prevent crash
+      }
     } catch (error) {
       console.error("Failed to fetch agents:", error);
       toast.error('Failed to fetch agents');
@@ -54,7 +60,13 @@ const Dashboard = () => {
         throw new Error(`HTTP error! status: ${response.status}`);
       }
       const data = await response.json();
-      setWorkflows(data);
+      if (Array.isArray(data)) {
+        setWorkflows(data);
+      } else {
+        console.error("Received non-array data for workflows:", data);
+        toast.error('Received invalid data for workflows');
+        setWorkflows([]); // Set to empty array to prevent crash
+      }
     } catch (error) {
       console.error("Failed to fetch workflows:", error);
       toast.error('Failed to fetch workflows');


### PR DESCRIPTION
A persistent `TypeError: e.map is not a function` error indicates that the component is receiving non-array data from the API, even with `try...catch` blocks in place. This suggests an API is returning a successful response with a non-array JSON body.

This change adds a final layer of defense by explicitly checking if the fetched data is an array using `Array.isArray()` before calling the state setter. If the data is not an array, it defaults to an empty array, which prevents the `.map()` call from crashing the component. This ensures client-side stability regardless of the data returned by the API.