### PR TITLE
refactor(services): Use absolute path aliases for imports

### DIFF
--- a/src/services/agentService.ts
+++ b/src/services/agentService.ts
@@ -1,8 +1,8 @@
 import { v4 as uuidv4 } from 'uuid';
-import { RoleSpecificAgent, AgentRole, TaskInfo, TaskResult } from '../types/agents';
-import { AgentType, getModelForAgent, getFallbackModel } from '../lib/config/modelConfig';
-import { EmailService } from './emailService';
-import { WebSocketService } from '../utils/websocket';
+import { RoleSpecificAgent, AgentRole, TaskInfo, TaskResult } from '@/types/agents';
+import { AgentType, getModelForAgent, getFallbackModel } from '@/lib/config/modelConfig';
+import { EmailService } from '@/services/emailService';
+import { WebSocketService } from '@/utils/websocket';
 
 export class AgentService {
   private static instance: AgentService;

--- a/src/services/crewAIService.ts
+++ b/src/services/crewAIService.ts
@@ -1,6 +1,6 @@
-import { RoleSpecificAgent, TaskInfo, TaskResult } from '../types/agents';
-import { MemoryService } from './memoryService';
-import { MemorySearchResult } from '../types/memory';
+import { RoleSpecificAgent, TaskInfo, TaskResult } from '@/types/agents';
+import { MemoryService } from '@/services/memoryService';
+import { MemorySearchResult } from '@/types/memory';
 
 interface CrewTask {
   id: string;

--- a/src/services/memoryService.ts
+++ b/src/services/memoryService.ts
@@ -1,16 +1,16 @@
 import { QdrantClient } from '@qdrant/js-client-rest';
 import { v4 as uuidv4 } from 'uuid';
-import { 
-  MemoryVector, 
-  MemorySearchResult, 
+import {
+  MemoryVector,
+  MemorySearchResult,
   ShortTermMemory,
   MemoryQueryOptions,
   AgentPerformanceMetrics,
   PostmortemAnalysis,
   HumanFeedback
-} from '../types/memory';
-import { MEMORY_CONFIG, MEMORY_COLLECTIONS } from '../config/memoryConfig';
-import { EmbeddingsService } from './embeddingsService';
+} from '@/types/memory';
+import { MEMORY_CONFIG, MEMORY_COLLECTIONS } from '@/config/memoryConfig';
+import { EmbeddingsService } from '@/services/embeddingsService';
 
 export class MemoryService {
   private static instance: MemoryService;

--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -1,5 +1,5 @@
-import { EmailService } from './emailService';
-import { WebSocketService } from '../utils/websocket';
+import { EmailService } from '@/services/emailService';
+import { WebSocketService } from '@/utils/websocket';
 import { WebClient } from '@slack/web-api';
 
 interface NotificationConfig {


### PR DESCRIPTION
A `TypeError: Property 'broadcast' does not exist on type 'WebSocketService'` build error indicated a subtle module resolution issue.

This commit refactors all service files (`notificationService`, `agentService`, `crewAIService`, `memoryService`) to use the absolute `@/` path alias defined in `tsconfig.json` instead of relative paths (`../`).

This enforces a consistent import strategy across the application, preventing potential type conflicts and making the codebase more robust and maintainable.