### PR TITLE
chore: Comment out broadcast call for diagnostics

### DIFF
--- a/src/services/notificationService.ts
+++ b/src/services/notificationService.ts
@@ -61,12 +61,12 @@ export class NotificationService {
       );
     }
 
-    if (config.websocket) {
-      this.wsService.broadcast({
-        type: 'NOTIFICATION',
-        payload: message
-      });
-    }
+    // if (config.websocket) {
+    //   this.wsService.broadcast({
+    //     type: 'NOTIFICATION',
+    //     payload: message
+    //   });
+    // }
 
     await Promise.all(notifications);
   }


### PR DESCRIPTION
This commit comments out the call to `this.wsService.broadcast` in `notificationService.ts`.

This is not a fix, but a diagnostic step to isolate a persistent build error (`Property 'broadcast' does not exist...`). If the build succeeds with this line commented out, it confirms the issue is localized to this specific method call.