### PR TITLE
This commit adds the missing pages for the `/agents` and `/tasks` rou…

### DIFF
--- a/src/pages/agents/index.tsx
+++ b/src/pages/agents/index.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Head from 'next/head';
+import Navigation from '../../components/Navigation';
+import Agents from '../../components/Agents';
+
+const AgentsPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Agents - Vibecoded</title>
+        <meta name="description" content="Manage your AI agents." />
+      </Head>
+      <Navigation />
+      <main>
+        <Agents />
+      </main>
+    </>
+  );
+};
+
+export default AgentsPage;

--- a/src/pages/tasks.tsx
+++ b/src/pages/tasks.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import Head from 'next/head';
+import Navigation from '../components/Navigation';
+import Tasks from '../components/Tasks';
+
+const TasksPage = () => {
+  return (
+    <>
+      <Head>
+        <title>Tasks - Vibecoded</title>
+        <meta name="description" content="Manage your tasks." />
+      </Head>
+      <Navigation />
+      <main>
+        <Tasks />
+      </main>
+    </>
+  );
+};
+
+export default TasksPage;


### PR DESCRIPTION
…tes, which were causing 404 Not Found errors.

The new pages are:
- `src/pages/agents/index.tsx`: This page displays a list of agents by using the existing `Agents` component.
- `src/pages/tasks.tsx`: This page displays a list of tasks by using the existing `Tasks` component.

These changes ensure that the navigation links for "Agents" and "Tasks" now lead to their corresponding pages instead of a 404 error page.